### PR TITLE
Added support of SEN-14001 (9DoF Razor IMU M0)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package razor_imu_9dof
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+1.2.0 (20-12-2017)
+------------------
+* Adding firmware support for SEN-14001 (9DoF Razor IMU M0) from https://github.com/lebarsfa/razor-9dof-ahrs (`#28 <https://github.com/KristofRobot/razor_imu_9dof/issues/28>`_).
+
+    * Note: 
+		* For SEN-14001 (9DoF Razor IMU M0), you will need to follow the same instructions as for the default firmware on https://learn.sparkfun.com/tutorials/9dof-razor-imu-m0-hookup-guide and use an updated version of SparkFun_MPU-9250-DMP_Arduino_Library from https://github.com/lebarsfa/SparkFun_MPU-9250-DMP_Arduino_Library (an updated version of the default firmware is also available on https://github.com/lebarsfa/9DOF_Razor_IMU).
+		* There is also a minor update in the calibration tools provided.
+    
 1.1.1 (02-07-2016)
 ------------------
 * Passing razor_config_file as ros parameter in launch file (Daniel Koguciuk)

--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@ Install and Configure ROS Package
 
 Install Arduino firmware
 -------------------------
-1) Open ``src/Razor_AHRS/Razor_AHRS.ino`` in Arduino IDE. Note: this is a modified version
+1) For SEN-14001 (9DoF Razor IMU M0), you will need to follow the same instructions as for the default firmware on https://learn.sparkfun.com/tutorials/9dof-razor-imu-m0-hookup-guide and use an updated version of SparkFun_MPU-9250-DMP_Arduino_Library from https://github.com/lebarsfa/SparkFun_MPU-9250-DMP_Arduino_Library (an updated version of the default firmware is also available on https://github.com/lebarsfa/9DOF_Razor_IMU).
+
+2) Open ``src/Razor_AHRS/Razor_AHRS.ino`` in Arduino IDE. Note: this is a modified version
 of Peter Bartz' original Arduino code (see https://github.com/ptrbrtz/razor-9dof-ahrs). 
 Use this version - it emits linear acceleration and angular velocity data required by the ROS Imu message
 
-2) Select your hardware here by uncommenting the right line in ``src/Razor_AHRS/Razor_AHRS.ino``, e.g.
+3) Select your hardware here by uncommenting the right line in ``src/Razor_AHRS/Razor_AHRS.ino``, e.g.
 
 <pre>
 // HARDWARE OPTIONS
@@ -33,12 +35,13 @@ Use this version - it emits linear acceleration and angular velocity data requir
 // Select your hardware here by uncommenting one line!
 //#define HW__VERSION_CODE 10125 // SparkFun "9DOF Razor IMU" version "SEN-10125" (HMC5843 magnetometer)
 //#define HW__VERSION_CODE 10736 // SparkFun "9DOF Razor IMU" version "SEN-10736" (HMC5883L magnetometer)
+#define HW__VERSION_CODE 14001 // SparkFun "9DoF Razor IMU M0" version "SEN-14001"
 //#define HW__VERSION_CODE 10183 // SparkFun "9DOF Sensor Stick" version "SEN-10183" (HMC5843 magnetometer)
 //#define HW__VERSION_CODE 10321 // SparkFun "9DOF Sensor Stick" version "SEN-10321" (HMC5843 magnetometer)
-#define HW__VERSION_CODE 10724 // SparkFun "9DOF Sensor Stick" version "SEN-10724" (HMC5883L magnetometer)
+//#define HW__VERSION_CODE 10724 // SparkFun "9DOF Sensor Stick" version "SEN-10724" (HMC5883L magnetometer)
 </pre>
 
-3) Upload Arduino sketch to the Sparkfun 9DOF Razor IMU board
+4) Upload Arduino sketch to the Sparkfun 9DOF Razor IMU board
 
 
 Configure
@@ -80,7 +83,7 @@ For best accuracy, follow the tutorial to calibrate the sensors:
 
 http://wiki.ros.org/razor_imu_9dof
 
-A copy of Peter Bartz's magnetometer calibration scripts from https://github.com/ptrbrtz/razor-9dof-ahrs is provided in the ``magnetometer_calibration`` directory.
+An updated version of Peter Bartz's magnetometer calibration scripts from https://github.com/ptrbrtz/razor-9dof-ahrs is provided in the ``magnetometer_calibration`` directory.
 
 Update ``my_razor.yaml`` with the new calibration parameters.
 

--- a/magnetometer_calibration/Matlab/magnetometer_calibration/magnetometer_calibration.m
+++ b/magnetometer_calibration/Matlab/magnetometer_calibration/magnetometer_calibration.m
@@ -35,9 +35,9 @@ S = comp * S; % do compensation
 % output info
 fprintf('In the Razor_AHRS.ino, under "SENSOR CALIBRATION" find the section that reads "Magnetometer (extended calibration)"\n');
 fprintf('Replace the existing 3 lines with these:\n\n');
-fprintf('#define CALIBRATION__MAGN_USE_EXTENDED true\n');
-fprintf('const float magn_ellipsoid_center[3] = {%.6g, %.6g, %.6g};\n', e_center);
-fprintf('const float magn_ellipsoid_transform[3][3] = {{%.6g, %.6g, %.6g}, {%.6g, %.6g, %.6g}, {%.6g, %.6g, %.6g}};\n', comp);
+fprintf('boolean CALIBRATION__MAGN_USE_EXTENDED = true;\n');
+fprintf('float magn_ellipsoid_center[3] = {%.6g, %.6g, %.6g};\n', e_center);
+fprintf('float magn_ellipsoid_transform[3][3] = {{%.6g, %.6g, %.6g}, {%.6g, %.6g, %.6g}, {%.6g, %.6g, %.6g}};\n', comp);
 
 % draw ellipsoid fit
 figure;

--- a/magnetometer_calibration/Processing/Magnetometer_calibration/Magnetometer_calibration.pde
+++ b/magnetometer_calibration/Processing/Magnetometer_calibration/Magnetometer_calibration.pde
@@ -366,9 +366,9 @@ void outputCalibration() {
   // Output calibration
   System.out.printf("In the Razor_AHRS.ino, under 'SENSOR CALIBRATION' find the section that reads 'Magnetometer (extended calibration)'\n");
   System.out.printf("Replace the existing 3 lines with these:\n\n");
-  System.out.printf("#define CALIBRATION__MAGN_USE_EXTENDED true\n");
-  System.out.printf("const float magn_ellipsoid_center[3] = {%.6g, %.6g, %.6g};\n", center.get(0), center.get(1), center.get(2));
-  System.out.printf("const float magn_ellipsoid_transform[3][3] = {{%.6g, %.6g, %.6g}, {%.6g, %.6g, %.6g}, {%.6g, %.6g, %.6g}};\n",
+  System.out.printf("boolean CALIBRATION__MAGN_USE_EXTENDED = true;\n");
+  System.out.printf("float magn_ellipsoid_center[3] = {%.6g, %.6g, %.6g};\n", center.get(0), center.get(1), center.get(2));
+  System.out.printf("float magn_ellipsoid_transform[3][3] = {{%.6g, %.6g, %.6g}, {%.6g, %.6g, %.6g}, {%.6g, %.6g, %.6g}};\n",
     comp.get(0), comp.get(1), comp.get(2), comp.get(3), comp.get(4), comp.get(5), comp.get(6), comp.get(7), comp.get(8));
   println("\n");
 }

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>razor_imu_9dof</name>
-  <version>1.1.1</version>
+  <version>1.2.0</version>
   <description>
      razor_imu_9dof is a package that provides a ROS driver
      for the Sparkfun Razor IMU 9DOF. It also provides Arduino

--- a/src/Razor_AHRS/Compass.ino
+++ b/src/Razor_AHRS/Compass.ino
@@ -2,12 +2,12 @@
 
 void Compass_Heading()
 {
-  float mag_x;
-  float mag_y;
-  float cos_roll;
-  float sin_roll;
-  float cos_pitch;
-  float sin_pitch;
+  float mag_x = 0;
+  float mag_y = 0;
+  float cos_roll = 0;
+  float sin_roll = 0;
+  float cos_pitch = 0;
+  float sin_pitch = 0;
   
   cos_roll = cos(roll);
   sin_roll = sin(roll);

--- a/src/Razor_AHRS/Output.ino
+++ b/src/Razor_AHRS/Output.ino
@@ -9,14 +9,14 @@ void output_angles()
     ypr[0] = TO_DEG(yaw);
     ypr[1] = TO_DEG(pitch);
     ypr[2] = TO_DEG(roll);
-    Serial.write((byte*) ypr, 12);  // No new-line
+    LOG_PORT.write((byte*) ypr, 12);  // No new-line
   }
   else if (output_format == OUTPUT__FORMAT_TEXT)
   {
-    Serial.print("#YPR=");
-    Serial.print(TO_DEG(yaw)); Serial.print(",");
-    Serial.print(TO_DEG(pitch)); Serial.print(",");
-    Serial.print(TO_DEG(roll)); Serial.println();
+    LOG_PORT.print("#YPR=");
+    LOG_PORT.print(TO_DEG(yaw)); LOG_PORT.print(",");
+    LOG_PORT.print(TO_DEG(pitch)); LOG_PORT.print(",");
+    LOG_PORT.print(TO_DEG(roll)); LOG_PORT.println();
   }
 }
 
@@ -25,29 +25,29 @@ void output_calibration(int calibration_sensor)
   if (calibration_sensor == 0)  // Accelerometer
   {
     // Output MIN/MAX values
-    Serial.print("accel x,y,z (min/max) = ");
+    LOG_PORT.print("accel x,y,z (min/max) = ");
     for (int i = 0; i < 3; i++) {
       if (accel[i] < accel_min[i]) accel_min[i] = accel[i];
       if (accel[i] > accel_max[i]) accel_max[i] = accel[i];
-      Serial.print(accel_min[i]);
-      Serial.print("/");
-      Serial.print(accel_max[i]);
-      if (i < 2) Serial.print("  ");
-      else Serial.println();
+      LOG_PORT.print(accel_min[i]);
+      LOG_PORT.print("/");
+      LOG_PORT.print(accel_max[i]);
+      if (i < 2) LOG_PORT.print("  ");
+      else LOG_PORT.println();
     }
   }
   else if (calibration_sensor == 1)  // Magnetometer
   {
     // Output MIN/MAX values
-    Serial.print("magn x,y,z (min/max) = ");
+    LOG_PORT.print("magn x,y,z (min/max) = ");
     for (int i = 0; i < 3; i++) {
       if (magnetom[i] < magnetom_min[i]) magnetom_min[i] = magnetom[i];
       if (magnetom[i] > magnetom_max[i]) magnetom_max[i] = magnetom[i];
-      Serial.print(magnetom_min[i]);
-      Serial.print("/");
-      Serial.print(magnetom_max[i]);
-      if (i < 2) Serial.print("  ");
-      else Serial.println();
+      LOG_PORT.print(magnetom_min[i]);
+      LOG_PORT.print("/");
+      LOG_PORT.print(magnetom_max[i]);
+      if (i < 2) LOG_PORT.print("  ");
+      else LOG_PORT.println();
     }
   }
   else if (calibration_sensor == 2)  // Gyroscope
@@ -58,56 +58,56 @@ void output_calibration(int calibration_sensor)
     gyro_num_samples++;
       
     // Output current and averaged gyroscope values
-    Serial.print("gyro x,y,z (current/average) = ");
+    LOG_PORT.print("gyro x,y,z (current/average) = ");
     for (int i = 0; i < 3; i++) {
-      Serial.print(gyro[i]);
-      Serial.print("/");
-      Serial.print(gyro_average[i] / (float) gyro_num_samples);
-      if (i < 2) Serial.print("  ");
-      else Serial.println();
+      LOG_PORT.print(gyro[i]);
+      LOG_PORT.print("/");
+      LOG_PORT.print(gyro_average[i] / (float) gyro_num_samples);
+      if (i < 2) LOG_PORT.print("  ");
+      else LOG_PORT.println();
     }
   }
 }
 
 void output_sensors_text(char raw_or_calibrated)
 {
-  Serial.print("#A-"); Serial.print(raw_or_calibrated); Serial.print('=');
-  Serial.print(accel[0]); Serial.print(",");
-  Serial.print(accel[1]); Serial.print(",");
-  Serial.print(accel[2]); Serial.println();
+  LOG_PORT.print("#A-"); LOG_PORT.print(raw_or_calibrated); LOG_PORT.print('=');
+  LOG_PORT.print(accel[0]); LOG_PORT.print(",");
+  LOG_PORT.print(accel[1]); LOG_PORT.print(",");
+  LOG_PORT.print(accel[2]); LOG_PORT.println();
 
-  Serial.print("#M-"); Serial.print(raw_or_calibrated); Serial.print('=');
-  Serial.print(magnetom[0]); Serial.print(",");
-  Serial.print(magnetom[1]); Serial.print(",");
-  Serial.print(magnetom[2]); Serial.println();
+  LOG_PORT.print("#M-"); LOG_PORT.print(raw_or_calibrated); LOG_PORT.print('=');
+  LOG_PORT.print(magnetom[0]); LOG_PORT.print(",");
+  LOG_PORT.print(magnetom[1]); LOG_PORT.print(",");
+  LOG_PORT.print(magnetom[2]); LOG_PORT.println();
 
-  Serial.print("#G-"); Serial.print(raw_or_calibrated); Serial.print('=');
-  Serial.print(gyro[0]); Serial.print(",");
-  Serial.print(gyro[1]); Serial.print(",");
-  Serial.print(gyro[2]); Serial.println();
+  LOG_PORT.print("#G-"); LOG_PORT.print(raw_or_calibrated); LOG_PORT.print('=');
+  LOG_PORT.print(gyro[0]); LOG_PORT.print(",");
+  LOG_PORT.print(gyro[1]); LOG_PORT.print(",");
+  LOG_PORT.print(gyro[2]); LOG_PORT.println();
 }
 
 void output_both_angles_and_sensors_text()
 {
-  Serial.print("#YPRAG=");
-  Serial.print(TO_DEG(yaw)); Serial.print(",");
-  Serial.print(TO_DEG(pitch)); Serial.print(",");
-  Serial.print(TO_DEG(roll)); Serial.print(",");
+  LOG_PORT.print("#YPRAG=");
+  LOG_PORT.print(TO_DEG(yaw)); LOG_PORT.print(",");
+  LOG_PORT.print(TO_DEG(pitch)); LOG_PORT.print(",");
+  LOG_PORT.print(TO_DEG(roll)); LOG_PORT.print(",");
   
-  Serial.print(Accel_Vector[0]); Serial.print(",");
-  Serial.print(Accel_Vector[1]); Serial.print(",");
-  Serial.print(Accel_Vector[2]); Serial.print(",");
+  LOG_PORT.print(Accel_Vector[0]); LOG_PORT.print(",");
+  LOG_PORT.print(Accel_Vector[1]); LOG_PORT.print(",");
+  LOG_PORT.print(Accel_Vector[2]); LOG_PORT.print(",");
 
-  Serial.print(Gyro_Vector[0]); Serial.print(",");
-  Serial.print(Gyro_Vector[1]); Serial.print(",");
-  Serial.print(Gyro_Vector[2]); Serial.println();
+  LOG_PORT.print(Gyro_Vector[0]); LOG_PORT.print(",");
+  LOG_PORT.print(Gyro_Vector[1]); LOG_PORT.print(",");
+  LOG_PORT.print(Gyro_Vector[2]); LOG_PORT.println();
 }
 
 void output_sensors_binary()
 {
-  Serial.write((byte*) accel, 12);
-  Serial.write((byte*) magnetom, 12);
-  Serial.write((byte*) gyro, 12);
+  LOG_PORT.write((byte*) accel, 12);
+  LOG_PORT.write((byte*) magnetom, 12);
+  LOG_PORT.write((byte*) gyro, 12);
 }
 
 void output_sensors()

--- a/src/Razor_AHRS/Razor_AHRS.ino
+++ b/src/Razor_AHRS/Razor_AHRS.ino
@@ -1,5 +1,5 @@
 /***************************************************************************************************************
-* Razor AHRS Firmware v1.4.2.2
+* Razor AHRS Firmware
 * 9 Degree of Measurement Attitude and Heading Reference System
 * for Sparkfun "9DOF Razor IMU" (SEN-10125 and SEN-10736)
 * and "9DOF Sensor Stick" (SEN-10183, 10321 and SEN-10724)
@@ -41,18 +41,43 @@
 *       * Added support for SparkFun "9DOF Sensor Stick" (versions SEN-10183, SEN-10321 and SEN-10724).
 *     * v1.4.1
 *       * Added output modes to read raw and/or calibrated sensor data in text or binary format.
-*       * Added static magnetometer soft iron distortion compensation
+*       * Added static magnetometer soft iron distortion compensation.
 *     * v1.4.2
 *       * (No core firmware changes)
-*     * v1.4.2.1
-*       * New output mode to support ROS Imu use emits YPR + accel + rot. vel.
-*     * v1.4.2.2
-*       * New input mode to set calibration parameters
+*     * v1.5
+*       * Added support for "9DoF Razor IMU M0": SEN-14001.
+*     * v1.5.1
+*       * Added ROS-compatible output mode.
+*     * v1.5.2
+*       * Added ROS-compatible input mode to set calibration parameters.
+*     * v1.5.3
+*       * Fixed the problem where commands were ignored by the M0 depending on how they were sent.
+*     * v1.5.4
+*       * Attempts to fix random nan problems in orientation computations.
+*       * Added an option to get yaw/pitch/roll from the M0 DMP.
+*       * Added a command to enable/disable the use of magnetometers for yaw computation.
+*     * v1.5.5
+*       * Added various options to determine the most stable configuration for the M0.
+*     * v1.5.6
+*       * Removed some unnecessary math error checking.
+*       * Set back gyro full-scale range to the maximum for the M0.
+*       * Increased startup delay to try to get a correct initial orientation for the M0.
+*     * v1.5.7
+*       * Calibration data are now also used to compute the initial orientation.
 *
 * TODOs:
-*   * Allow optional use of EEPROM for storing and reading calibration values.
+*   * Allow optional use of Flash/EEPROM for storing and reading calibration values.
 *   * Use self-test and temperature-compensation features of the sensors.
 ***************************************************************************************************************/
+
+/*
+  "9DoF Razor IMU M0" hardware versions: SEN-14001
+
+  Arduino IDE : Follow the same instructions as for the default firmware on 
+  https://learn.sparkfun.com/tutorials/9dof-razor-imu-m0-hookup-guide 
+  and use an updated version of SparkFun_MPU-9250-DMP_Arduino_Library from 
+  https://github.com/lebarsfa/SparkFun_MPU-9250-DMP_Arduino_Library"
+*/
 
 /*
   "9DOF Razor IMU" hardware versions: SEN-10125 and SEN-10736
@@ -93,11 +118,13 @@
   Serial commands that the firmware understands:
   
   "#c<params>" - SET _c_alibration parameters. The available options are:
-    [a|m|g|c|t] _a_ccelerometer, _m_agnetometer, _g_yro, magnetometerellipsoid_c_enter, magnetometerellipsoid_t_ransform
-    [x|y|z] x,y or z 
-    [m|M|X|Y|Z] _m_in or _M_ax (accel or magnetometer), X, Y, or Z of transform (magnetometerellipsoid_t_ransform)
+    [a|m|g|c|t] _a_ccelerometer, _m_agnetometer, _g_yro, magnetometerellipsoid_c_enter, magnetometerellipsoid_t_ransform.
+    [x|y|z] x,y or z.
+    [m|M|X|Y|Z] _m_in or _M_ax (accel or magnetometer), X, Y, or Z of transform (magnetometerellipsoid_t_ransform).
 
-  "#p" - PRINT current calibration values
+
+  "#p" - PRINT current calibration values.
+
 
   "#o<params>" - Set OUTPUT mode and parameters. The available options are:
   
@@ -113,9 +140,10 @@
       "#ox" - Output angles and linear acceleration and rotational
               velocity. Angles are in degrees, acceleration is
               in units of 1.0 = 1/256 G (9.8/256 m/s^2). Rotational
-              velocity is in rad/s^2. (Output frames have form like
+              velocity is in rad/s. (Output frames have form like
               "#YPRAG=-142.28,-5.38,33.52,0.1,0.1,1.0,0.01,0.01,0.01",
               followed by carriage return and line feed [\r\n]).
+     
       // Sensor calibration
       "#oc" - Go to CALIBRATION output mode.
       "#on" - When in calibration mode, go on to calibrate NEXT sensor.
@@ -139,20 +167,25 @@
       // Error message output        
       "#oe0" - Disable ERROR message output.
       "#oe1" - Enable ERROR message output.
-    
-    
+      "#oec" - Output ERROR COUNT.
+      "#oem" - Output MATH ERROR COUNT.
+
+
+  "#I" - Toggle INERTIAL-only mode for yaw computation.
+
+
   "#f" - Request one output frame - useful when continuous output is disabled and updates are
          required in larger intervals only. Though #f only requests one reply, replies are still
          bound to the internal 20ms (50Hz) time raster. So worst case delay that #f can add is 19.99ms.
-         
-         
+ 
+  
   "#s<xy>" - Request synch token - useful to find out where the frame boundaries are in a continuous
          binary stream or to see if tracker is present and answering. The tracker will send
          "#SYNCH<xy>\r\n" in response (so it's possible to read using a readLine() function).
          x and y are two mandatory but arbitrary bytes that can be used to find out which request
          the answer belongs to.
-          
-          
+
+
   ("#C" and "#D" - Reserved for communication with optional Bluetooth module.)
   
   Newline characters are not required. So you could send "#ob#o1#s", which
@@ -175,6 +208,7 @@
 // Select your hardware here by uncommenting one line!
 //#define HW__VERSION_CODE 10125 // SparkFun "9DOF Razor IMU" version "SEN-10125" (HMC5843 magnetometer)
 //#define HW__VERSION_CODE 10736 // SparkFun "9DOF Razor IMU" version "SEN-10736" (HMC5883L magnetometer)
+//#define HW__VERSION_CODE 14001 // SparkFun "9DoF Razor IMU M0" version "SEN-14001"
 //#define HW__VERSION_CODE 10183 // SparkFun "9DOF Sensor Stick" version "SEN-10183" (HMC5843 magnetometer)
 //#define HW__VERSION_CODE 10321 // SparkFun "9DOF Sensor Stick" version "SEN-10321" (HMC5843 magnetometer)
 //#define HW__VERSION_CODE 10724 // SparkFun "9DOF Sensor Stick" version "SEN-10724" (HMC5883L magnetometer)
@@ -184,6 +218,13 @@
 /*****************************************************************/
 // Set your serial port baud rate used to send out data here!
 #define OUTPUT__BAUD_RATE 57600
+#if HW__VERSION_CODE == 14001
+// Set your port used to send out data here!
+#define LOG_PORT SERIAL_PORT_USBVIRTUAL
+#else
+// Set your port used to send out data here!
+#define LOG_PORT Serial
+#endif // HW__VERSION_CODE
 
 // Sensor data output interval in milliseconds
 // This may not work, if faster than 20ms (=50Hz)
@@ -206,7 +247,7 @@ int output_mode = OUTPUT__MODE_ANGLES;
 int output_format = OUTPUT__FORMAT_TEXT;
 
 // Select if serial continuous streaming output is enabled per default on startup.
-#define OUTPUT__STARTUP_STREAM_ON false  // true or false
+#define OUTPUT__STARTUP_STREAM_ON true  // true or false
 
 // If set true, an error message will be output if we fail to read sensor data.
 // Message format: "!ERR: reading <sensor>", followed by "\r\n".
@@ -228,6 +269,7 @@ boolean output_errors = false;  // true or false
 /*****************************************************************/
 // How to calibrate? Read the tutorial at http://dev.qu.tu-berlin.de/projects/sf-razor-9dof-ahrs
 // Put MIN/MAX and OFFSET readings for your board here!
+// For the M0, only the extended magnetometer calibration seems to be really necessary if DEBUG__USE_DMP_M0 is set to true...
 // Accelerometer
 // "accel x,y,z (min/max) = X_MIN/X_MAX  Y_MIN/Y_MAX  Z_MIN/Z_MAX"
 float ACCEL_X_MIN = -250;
@@ -258,13 +300,67 @@ float GYRO_AVERAGE_OFFSET_X = 0.0;
 float GYRO_AVERAGE_OFFSET_Y = 0.0;
 float GYRO_AVERAGE_OFFSET_Z = 0.0;
 
+/*
+// Calibration example:
+
+// "accel x,y,z (min/max) = -277.00/264.00  -256.00/278.00  -299.00/235.00"
+float ACCEL_X_MIN = -277;
+float ACCEL_X_MAX = 264;
+float ACCEL_Y_MIN = -256;
+float ACCEL_Y_MAX = 278;
+float ACCEL_Z_MIN = -299;
+float ACCEL_Z_MAX = 235;
+
+// "magn x,y,z (min/max) = -511.00/581.00  -516.00/568.00  -489.00/486.00"
+float MAGN_X_MIN = -511;
+float MAGN_X_MAX = 581;
+float MAGN_Y_MIN = -516;
+float MAGN_Y_MAX = 568;
+float MAGN_Z_MIN = -489;
+float MAGN_Z_MAX = 486;
+
+// Extended magn
+boolean CALIBRATION__MAGN_USE_EXTENDED = true;
+float magn_ellipsoid_center[3] = {91.5, -13.5, -48.1};
+float magn_ellipsoid_transform[3][3] = {{0.902, -0.00354, 0.000636}, {-0.00354, 0.9, -0.00599}, {0.000636, -0.00599, 1}};
+
+// Extended magn (with Sennheiser HD 485 headphones)
+//boolean CALIBRATION__MAGN_USE_EXTENDED = true;
+//float magn_ellipsoid_center[3] = {72.3360, 23.0954, 53.6261};
+//float magn_ellipsoid_transform[3][3] = {{0.879685, 0.000540833, -0.0106054}, {0.000540833, 0.891086, -0.0130338}, {-0.0106054, -0.0130338, 0.997494}};
+
+//"gyro x,y,z (current/average) = -40.00/-42.05  98.00/96.20  -18.00/-18.36"
+float GYRO_AVERAGE_OFFSET_X = -42.05;
+float GYRO_AVERAGE_OFFSET_Y = 96.20;
+float GYRO_AVERAGE_OFFSET_Z = -18.36;
+*/
+
 
 // DEBUG OPTIONS
 /*****************************************************************/
 // When set to true, gyro drift correction will not be applied
-#define DEBUG__NO_DRIFT_CORRECTION false
+boolean DEBUG__NO_DRIFT_CORRECTION = false;
 // Print elapsed time after each I/O loop
 #define DEBUG__PRINT_LOOP_TIME false
+
+#define DEBUG__PRINT_LOOP_TIME_2 false
+
+#define DEBUG__ADD_LOOP_DELAY false
+
+#define DEBUG__LOOP_DELAY 1
+// Set to true to enable auto-calibration features of the M0 (does not apply to magnetometers)
+#define DEBUG__USE_DMP_M0 false
+// Set to true to disable the use of the DCM algorithm
+#define DEBUG__USE_ONLY_DMP_M0 false
+
+#define DEBUG__ENABLE_FIFO_M0 false
+
+#define DEBUG__ENABLE_INTERRUPT_M0 false
+
+#define DEBUG__USE_DEFAULT_GYRO_FSR_M0 false
+
+#define DEBUG__USE_DEFAULT_ACCEL_FSR_M0 false
+
 
 
 /*****************************************************************/
@@ -286,7 +382,34 @@ float GYRO_AVERAGE_OFFSET_Z = 0.0;
   #error YOU HAVE TO SELECT THE HARDWARE YOU ARE USING! See "HARDWARE OPTIONS" in "USER SETUP AREA" at top of Razor_AHRS.ino!
 #endif
 
+#if HW__VERSION_CODE == 14001
+// MPU-9250 Digital Motion Processing (DMP) Library
+#include <SparkFunMPU9250-DMP.h>
+
+// Danger - don't change unless using a different platform
+#define MPU9250_INT_PIN 4
+#define SD_CHIP_SELECT_PIN 38
+#define MPU9250_INT_ACTIVE LOW
+
+MPU9250_DMP imu; // Create an instance of the MPU9250_DMP class
+
+#if DEBUG__USE_ONLY_DMP_M0 == true
+#undef DEBUG__USE_DMP_M0
+#define DEBUG__USE_DMP_M0 true
+#endif // DEBUG__USE_ONLY_DMP_M0
+
+#if DEBUG__USE_DMP_M0 == true
+#undef DEBUG__ENABLE_FIFO_M0
+#define DEBUG__ENABLE_FIFO_M0 true
+#endif // DEBUG__USE_DMP_M0
+
+#if DEBUG__USE_ONLY_DMP_M0 == true
+float initialmagyaw = -10000;
+float initialimuyaw = -10000;
+#endif // DEBUG__USE_ONLY_DMP_M0
+#else
 #include <Wire.h>
+#endif // HW__VERSION_CODE
 
 #define GRAVITY 256.0f // "1G reference" used for DCM filter and accelerometer calibration
 
@@ -306,9 +429,14 @@ float MAGN_Y_SCALE = (100.0f / (MAGN_Y_MAX - MAGN_Y_OFFSET));
 float MAGN_Z_SCALE = (100.0f / (MAGN_Z_MAX - MAGN_Z_OFFSET));
 
 
+
+#if HW__VERSION_CODE == 14001
+#define GYRO_SCALED_RAD(x) (x) // Calculate the scaled gyro readings in radians per second
+#else
 // Gain for gyroscope (ITG-3200)
 #define GYRO_GAIN 0.06957 // Same gain on all axes
 #define GYRO_SCALED_RAD(x) (x * TO_RAD(GYRO_GAIN)) // Calculate the scaled gyro readings in radians per second
+#endif // HW__VERSION_CODE
 
 // DCM parameters
 #define Kp_ROLLPITCH 0.02f
@@ -322,21 +450,21 @@ float MAGN_Z_SCALE = (100.0f / (MAGN_Z_MAX - MAGN_Z_OFFSET));
 #define TO_DEG(x) (x * 57.2957795131)  // *180/pi
 
 // Sensor variables
-float accel[3];  // Actually stores the NEGATED acceleration (equals gravity, if board not moving).
-float accel_min[3];
-float accel_max[3];
+float accel[3] = {0, 0, 0}; // Actually stores the NEGATED acceleration (equals gravity, if board not moving).
+float accel_min[3] = {0, 0, 0};
+float accel_max[3] = {0, 0, 0};
 
-float magnetom[3];
-float magnetom_min[3];
-float magnetom_max[3];
-float magnetom_tmp[3];
+float magnetom[3] = {0, 0, 0};
+float magnetom_min[3] = {0, 0, 0};
+float magnetom_max[3] = {0, 0, 0};
+float magnetom_tmp[3] = {0, 0, 0};
 
-float gyro[3];
-float gyro_average[3];
+float gyro[3] = {0, 0, 0};
+float gyro_average[3] = {0, 0, 0};
 int gyro_num_samples = 0;
 
 // DCM variables
-float MAG_Heading;
+float MAG_Heading = 0;
 float Accel_Vector[3]= {0, 0, 0}; // Store the acceleration in a vector
 float Gyro_Vector[3]= {0, 0, 0}; // Store the gyros turn rate in a vector
 float Omega_Vector[3]= {0, 0, 0}; // Corrected Gyro_Vector data
@@ -350,32 +478,37 @@ float Update_Matrix[3][3] = {{0, 1, 2}, {3, 4, 5}, {6, 7, 8}};
 float Temporary_Matrix[3][3] = {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}};
 
 // Euler angles
-float yaw;
-float pitch;
-float roll;
+float yaw = 0;
+float pitch = 0;
+float roll = 0;
 
 // DCM timing in the main loop
-unsigned long timestamp;
-unsigned long timestamp_old;
-float G_Dt; // Integration time for DCM algorithm
+unsigned long timestamp = 0;
+unsigned long timestamp_old = 0;
+float G_Dt = 0; // Integration time for DCM algorithm
 
 // More output-state variables
-boolean output_stream_on;
-boolean output_single_on;
+boolean output_stream_on = false;
+boolean output_single_on = false;
 int curr_calibration_sensor = 0;
 boolean reset_calibration_session_flag = true;
 int num_accel_errors = 0;
 int num_magn_errors = 0;
 int num_gyro_errors = 0;
+int num_math_errors = 0;
 
 void read_sensors() {
+#if HW__VERSION_CODE == 14001
+  loop_imu();
+#else
   Read_Gyro(); // Read gyroscope
   Read_Accel(); // Read accelerometer
   Read_Magn(); // Read magnetometer
+#endif // HW__VERSION_CODE
 }
 
-//should be called after every #ca calibration command
-void recalculateAccelCalibration(){
+// Should be called after every #ca calibration command
+void recalculateAccelCalibration() {
   ACCEL_X_OFFSET = ((ACCEL_X_MIN + ACCEL_X_MAX) / 2.0f);
   ACCEL_Y_OFFSET = ((ACCEL_Y_MIN + ACCEL_Y_MAX) / 2.0f);
   ACCEL_Z_OFFSET = ((ACCEL_Z_MIN + ACCEL_Z_MAX) / 2.0f);
@@ -384,8 +517,8 @@ void recalculateAccelCalibration(){
   ACCEL_Z_SCALE = (GRAVITY / (ACCEL_Z_MAX - ACCEL_Z_OFFSET));
 }
 
-//should be called after every #cm calibration command
-void recalculateMagnCalibration(){
+// Should be called after every #cm calibration command
+void recalculateMagnCalibration() {
   MAGN_X_OFFSET = ((MAGN_X_MIN + MAGN_X_MAX) / 2.0f);
   MAGN_Y_OFFSET = ((MAGN_Y_MIN + MAGN_Y_MAX) / 2.0f);
   MAGN_Z_OFFSET = ((MAGN_Z_MIN + MAGN_Z_MAX) / 2.0f);
@@ -394,15 +527,43 @@ void recalculateMagnCalibration(){
   MAGN_Z_SCALE = (100.0f / (MAGN_Z_MAX - MAGN_Z_OFFSET));
 }
 
+// Apply calibration to raw sensor readings
+void compensate_sensor_errors() {
+    // Compensate accelerometer error
+    accel[0] = (accel[0] - ACCEL_X_OFFSET) * ACCEL_X_SCALE;
+    accel[1] = (accel[1] - ACCEL_Y_OFFSET) * ACCEL_Y_SCALE;
+    accel[2] = (accel[2] - ACCEL_Z_OFFSET) * ACCEL_Z_SCALE;
+
+    // Compensate magnetometer error
+    if (CALIBRATION__MAGN_USE_EXTENDED)
+    {
+      for (int i = 0; i < 3; i++)
+        magnetom_tmp[i] = magnetom[i] - magn_ellipsoid_center[i];
+      Matrix_Vector_Multiply(magn_ellipsoid_transform, magnetom_tmp, magnetom);
+    } 
+    else 
+    {
+      magnetom[0] = (magnetom[0] - MAGN_X_OFFSET) * MAGN_X_SCALE;
+      magnetom[1] = (magnetom[1] - MAGN_Y_OFFSET) * MAGN_Y_SCALE;
+      magnetom[2] = (magnetom[2] - MAGN_Z_OFFSET) * MAGN_Z_SCALE;
+    }
+
+    // Compensate gyroscope error
+    gyro[0] -= GYRO_AVERAGE_OFFSET_X;
+    gyro[1] -= GYRO_AVERAGE_OFFSET_Y;
+    gyro[2] -= GYRO_AVERAGE_OFFSET_Z;
+}
+
 // Read every sensor and record a time stamp
 // Init DCM with unfiltered orientation
 // TODO re-init global vars?
 void reset_sensor_fusion() {
-  float temp1[3];
-  float temp2[3];
-  float xAxis[] = {1.0f, 0.0f, 0.0f};
+  float temp1[3] = {0, 0, 0};
+  float temp2[3] = {0, 0, 0};
+  float xAxis[3] = {1, 0, 0};
 
   read_sensors();
+  compensate_sensor_errors();
   timestamp = millis();
   
   // GET PITCH
@@ -424,30 +585,6 @@ void reset_sensor_fusion() {
   
   // Init rotation matrix
   init_rotation_matrix(DCM_Matrix, yaw, pitch, roll);
-}
-
-// Apply calibration to raw sensor readings
-void compensate_sensor_errors() {
-  // Compensate accelerometer error
-  accel[0] = (accel[0] - ACCEL_X_OFFSET) * ACCEL_X_SCALE;
-  accel[1] = (accel[1] - ACCEL_Y_OFFSET) * ACCEL_Y_SCALE;
-  accel[2] = (accel[2] - ACCEL_Z_OFFSET) * ACCEL_Z_SCALE;
-  
-  // Compensate magnetometer error
-  if (CALIBRATION__MAGN_USE_EXTENDED){
-    for (int i = 0; i < 3; i++)
-      magnetom_tmp[i] = magnetom[i] - magn_ellipsoid_center[i];
-    Matrix_Vector_Multiply(magn_ellipsoid_transform, magnetom_tmp, magnetom);
-  }else{
-    magnetom[0] = (magnetom[0] - MAGN_X_OFFSET) * MAGN_X_SCALE;
-    magnetom[1] = (magnetom[1] - MAGN_Y_OFFSET) * MAGN_Y_SCALE;
-    magnetom[2] = (magnetom[2] - MAGN_Z_OFFSET) * MAGN_Z_SCALE;
-  }
-  
-  // Compensate gyroscope error
-  gyro[0] -= GYRO_AVERAGE_OFFSET_X;
-  gyro[1] -= GYRO_AVERAGE_OFFSET_Y;
-  gyro[2] -= GYRO_AVERAGE_OFFSET_Z;
 }
 
 // Reset calibration session if reset_calibration_session_flag is set
@@ -486,14 +623,14 @@ void turn_output_stream_off()
 // Blocks until another byte is available on serial port
 char readChar()
 {
-  while (Serial.available() < 1) { } // Block
-  return Serial.read();
+  while (LOG_PORT.available() < 1) { } // Block
+  return LOG_PORT.read();
 }
 
 void setup()
 {
   // Init serial output
-  Serial.begin(OUTPUT__BAUD_RATE);
+  LOG_PORT.begin(OUTPUT__BAUD_RATE);
   
   // Init status LED
   pinMode (STATUS_LED_PIN, OUTPUT);
@@ -501,13 +638,25 @@ void setup()
 
   // Init sensors
   delay(50);  // Give sensors enough time to start
+#if HW__VERSION_CODE == 14001
+#if DEBUG__ENABLE_INTERRUPT_M0 == true
+  // Set up MPU-9250 interrupt input (active-low)
+  pinMode(MPU9250_INT_PIN, INPUT_PULLUP);
+#endif // DEBUG__ENABLE_INTERRUPT_M0
+  initIMU();
+#else
   I2C_Init();
   Accel_Init();
   Magn_Init();
   Gyro_Init();
+#endif // HW__VERSION_CODE
   
   // Read sensors, init DCM algorithm
+#if HW__VERSION_CODE == 14001
+  delay(400);  // Give sensors enough time to collect data
+#else
   delay(20);  // Give sensors enough time to collect data
+#endif // HW__VERSION_CODE
   reset_sensor_fusion();
 
   // Init output
@@ -522,11 +671,21 @@ void setup()
 void loop()
 {
   // Read incoming control messages
-  if (Serial.available() >= 2)
+ #if HW__VERSION_CODE == 14001
+  // Compatibility fix : if bytes are sent 1 by 1 without being read, available() might never return more than 1...
+  // Therefore, we need to read bytes 1 by 1 and the command byte needs to be a blocking read...
+  if (LOG_PORT.available() >= 1)
   {
-    if (Serial.read() == '#') // Start of new control message
+    if (LOG_PORT.read() == '#') // Start of new control message
     {
-      int command = Serial.read(); // Commands
+      int command = readChar(); // Commands
+#else
+  if (LOG_PORT.available() >= 2)
+  {
+    if (LOG_PORT.read() == '#') // Start of new control message
+    {
+      int command = LOG_PORT.read(); // Commands
+#endif // HW__VERSION_CODE
       if (command == 'f') // request one output _f_rame
         output_single_on = true;
       else if (command == 's') // _s_ynch request
@@ -537,9 +696,9 @@ void loop()
         id[1] = readChar();
         
         // Reply with synch message
-        Serial.print("#SYNCH");
-        Serial.write(id, 2);
-        Serial.println();
+        LOG_PORT.print("#SYNCH");
+        LOG_PORT.write(id, 2);
+        LOG_PORT.println();
       }
       else if (command == 'o') // Set _o_utput mode
       {
@@ -564,10 +723,10 @@ void loop()
           output_mode = OUTPUT__MODE_CALIBRATE_SENSORS;
           reset_calibration_session_flag = true;
         }
-        else if (output_param == 'x') // Go to _c_alibration mode for both sensor and angle comment: Tang
+        else if (output_param == 'x') // Output angles + accel + rot. vel as te_x_t
         {
           output_mode = OUTPUT__MODE_ANGLES_AG_SENSORS;
-          reset_calibration_session_flag = true;
+          output_format = OUTPUT__FORMAT_TEXT;
         }
         else if (output_param == 's') // Output _s_ensor values
         {
@@ -600,63 +759,68 @@ void loop()
           char error_param = readChar();
           if (error_param == '0') output_errors = false;
           else if (error_param == '1') output_errors = true;
-          else if (error_param == 'c') // get error count
+          else if (error_param == 'c') // get error _c_ount
           {
-            Serial.print("#AMG-ERR:");
-            Serial.print(num_accel_errors); Serial.print(",");
-            Serial.print(num_magn_errors); Serial.print(",");
-            Serial.println(num_gyro_errors);
+            LOG_PORT.print("#AMG-ERR:");
+            LOG_PORT.print(num_accel_errors); LOG_PORT.print(",");
+            LOG_PORT.print(num_magn_errors); LOG_PORT.print(",");
+            LOG_PORT.println(num_gyro_errors);
+          }
+          else if (error_param == 'm') // get _m_ath error count
+          {
+            LOG_PORT.print("#MATH-ERR:");
+            LOG_PORT.println(num_math_errors);
           }
         }
       }
       else if (command == 'p') // Set _p_rint calibration values
       {
-         Serial.print("ACCEL_X_MIN:");Serial.println(ACCEL_X_MIN);
-         Serial.print("ACCEL_X_MAX:");Serial.println(ACCEL_X_MAX);
-         Serial.print("ACCEL_Y_MIN:");Serial.println(ACCEL_Y_MIN);
-         Serial.print("ACCEL_Y_MAX:");Serial.println(ACCEL_Y_MAX);
-         Serial.print("ACCEL_Z_MIN:");Serial.println(ACCEL_Z_MIN);
-         Serial.print("ACCEL_Z_MAX:");Serial.println(ACCEL_Z_MAX);
-         Serial.println(""); 
-         Serial.print("MAGN_X_MIN:");Serial.println(MAGN_X_MIN);
-         Serial.print("MAGN_X_MAX:");Serial.println(MAGN_X_MAX);
-         Serial.print("MAGN_Y_MIN:");Serial.println(MAGN_Y_MIN);
-         Serial.print("MAGN_Y_MAX:");Serial.println(MAGN_Y_MAX);
-         Serial.print("MAGN_Z_MIN:");Serial.println(MAGN_Z_MIN);
-         Serial.print("MAGN_Z_MAX:");Serial.println(MAGN_Z_MAX);
-         Serial.println("");
-         Serial.print("MAGN_USE_EXTENDED:");
+         LOG_PORT.print("ACCEL_X_MIN:");LOG_PORT.println(ACCEL_X_MIN);
+         LOG_PORT.print("ACCEL_X_MAX:");LOG_PORT.println(ACCEL_X_MAX);
+         LOG_PORT.print("ACCEL_Y_MIN:");LOG_PORT.println(ACCEL_Y_MIN);
+         LOG_PORT.print("ACCEL_Y_MAX:");LOG_PORT.println(ACCEL_Y_MAX);
+         LOG_PORT.print("ACCEL_Z_MIN:");LOG_PORT.println(ACCEL_Z_MIN);
+         LOG_PORT.print("ACCEL_Z_MAX:");LOG_PORT.println(ACCEL_Z_MAX);
+         LOG_PORT.println(""); 
+         LOG_PORT.print("MAGN_X_MIN:");LOG_PORT.println(MAGN_X_MIN);
+         LOG_PORT.print("MAGN_X_MAX:");LOG_PORT.println(MAGN_X_MAX);
+         LOG_PORT.print("MAGN_Y_MIN:");LOG_PORT.println(MAGN_Y_MIN);
+         LOG_PORT.print("MAGN_Y_MAX:");LOG_PORT.println(MAGN_Y_MAX);
+         LOG_PORT.print("MAGN_Z_MIN:");LOG_PORT.println(MAGN_Z_MIN);
+         LOG_PORT.print("MAGN_Z_MAX:");LOG_PORT.println(MAGN_Z_MAX);
+         LOG_PORT.println("");
+         LOG_PORT.print("MAGN_USE_EXTENDED:");
          if (CALIBRATION__MAGN_USE_EXTENDED) 
-           Serial.println("true");
+           LOG_PORT.println("true");
          else
-           Serial.println("false");
-         Serial.print("magn_ellipsoid_center:[");Serial.print(magn_ellipsoid_center[0],4);Serial.print(",");
-         Serial.print(magn_ellipsoid_center[1],4);Serial.print(",");
-         Serial.print(magn_ellipsoid_center[2],4);Serial.println("]");
-         Serial.print("magn_ellipsoid_transform:[");
+           LOG_PORT.println("false");
+         LOG_PORT.print("magn_ellipsoid_center:[");LOG_PORT.print(magn_ellipsoid_center[0],4);LOG_PORT.print(",");
+         LOG_PORT.print(magn_ellipsoid_center[1],4);LOG_PORT.print(",");
+         LOG_PORT.print(magn_ellipsoid_center[2],4);LOG_PORT.println("]");
+         LOG_PORT.print("magn_ellipsoid_transform:[");
          for(int i = 0; i < 3; i++){
-           Serial.print("[");
+           LOG_PORT.print("[");
            for(int j = 0; j < 3; j++){
-             Serial.print(magn_ellipsoid_transform[i][j],7);
-             if (j < 2) Serial.print(",");
+             LOG_PORT.print(magn_ellipsoid_transform[i][j],7);
+             if (j < 2) LOG_PORT.print(",");
            }
-           Serial.print("]");
-           if (i < 2) Serial.print(",");
+           LOG_PORT.print("]");
+           if (i < 2) LOG_PORT.print(",");
          }
-         Serial.println("]");
-         Serial.println(""); 
-         Serial.print("GYRO_AVERAGE_OFFSET_X:");Serial.println(GYRO_AVERAGE_OFFSET_X);
-         Serial.print("GYRO_AVERAGE_OFFSET_Y:");Serial.println(GYRO_AVERAGE_OFFSET_Y);
-         Serial.print("GYRO_AVERAGE_OFFSET_Z:");Serial.println(GYRO_AVERAGE_OFFSET_Z);
+         LOG_PORT.println("]");
+         LOG_PORT.println(""); 
+         LOG_PORT.print("GYRO_AVERAGE_OFFSET_X:");LOG_PORT.println(GYRO_AVERAGE_OFFSET_X);
+         LOG_PORT.print("GYRO_AVERAGE_OFFSET_Y:");LOG_PORT.println(GYRO_AVERAGE_OFFSET_Y);
+         LOG_PORT.print("GYRO_AVERAGE_OFFSET_Z:");LOG_PORT.println(GYRO_AVERAGE_OFFSET_Z);
       }
-      else if (command == 'c') // Set _i_nput mode
+	  else if (command == 'c') // Set _i_nput mode
       {
         char input_param = readChar();
         if (input_param == 'a')  // Calibrate _a_ccelerometer
         {
           char axis_param = readChar();
           char type_param = readChar();
-          float value_param = Serial.parseFloat();
+          float value_param = LOG_PORT.parseFloat();
           if (axis_param == 'x')  // x value
           {
             if (type_param == 'm')
@@ -686,7 +850,7 @@ void loop()
           CALIBRATION__MAGN_USE_EXTENDED = false;
           char axis_param = readChar();
           char type_param = readChar();
-          float value_param = Serial.parseFloat();
+          float value_param = LOG_PORT.parseFloat();
           if (axis_param == 'x')  // x value
           {
             if (type_param == 'm')
@@ -715,7 +879,7 @@ void loop()
           //enable extended magnetometer calibration
           CALIBRATION__MAGN_USE_EXTENDED = true;
           char axis_param = readChar();
-          float value_param = Serial.parseFloat();
+          float value_param = LOG_PORT.parseFloat();
           if (axis_param == 'x')  // x value
               magn_ellipsoid_center[0] = value_param;
           else if (axis_param == 'y')  // y value
@@ -729,7 +893,7 @@ void loop()
           CALIBRATION__MAGN_USE_EXTENDED = true;
           char axis_param = readChar();
           char type_param = readChar();
-          float value_param = Serial.parseFloat();
+          float value_param = LOG_PORT.parseFloat();
           if (axis_param == 'x')  // x value
           {
             if (type_param == 'X')
@@ -761,15 +925,24 @@ void loop()
         else if (input_param == 'g')  // Calibrate _g_yro 
         {
           char axis_param = readChar();
-          float value_param = Serial.parseFloat();
+          float value_param = LOG_PORT.parseFloat();
           if (axis_param == 'x')  // x value
               GYRO_AVERAGE_OFFSET_X = value_param;
           else if (axis_param == 'y')  // y value
               GYRO_AVERAGE_OFFSET_Y = value_param;
           else if (axis_param == 'z')  // z value
               GYRO_AVERAGE_OFFSET_Z = value_param;
-         }
+        }
       }
+	  else if (command == 'I') // Toggle _i_nertial-only mode for yaw computation
+	  {
+		DEBUG__NO_DRIFT_CORRECTION = !DEBUG__NO_DRIFT_CORRECTION;
+#if DEBUG__USE_ONLY_DMP_M0 == true
+		// Update reference for yaw...
+		initialmagyaw = -MAG_Heading;
+		initialimuyaw = imu.yaw*PI/180.0f;
+#endif // DEBUG__USE_ONLY_DMP_M0
+	  }
 #if OUTPUT__HAS_RN_BLUETOOTH == true
       // Read messages from bluetooth module
       // For this to work, the connect/disconnect message prefix of the module has to be set to "#".
@@ -786,6 +959,10 @@ void loop()
   // Time to read the sensors again?
   if((millis() - timestamp) >= OUTPUT__DATA_INTERVAL)
   {
+#if DEBUG__PRINT_LOOP_TIME_2 == true
+    LOG_PORT.print("loop time (ms) = ");
+    LOG_PORT.println(millis() - timestamp);
+#endif // DEBUG__PRINT_LOOP_TIME_2
     timestamp_old = timestamp;
     timestamp = millis();
     if (timestamp > timestamp_old)
@@ -804,13 +981,17 @@ void loop()
     {
       // Apply sensor calibration
       compensate_sensor_errors();
-    
+
+#if DEBUG__USE_ONLY_DMP_M0 == true
+	  Euler_angles_only_DMP_M0();
+#else
       // Run DCM algorithm
       Compass_Heading(); // Calculate magnetic heading
       Matrix_update();
       Normalize();
       Drift_correction();
       Euler_angles();
+#endif // DEBUG__USE_ONLY_DMP_M0
       
       if (output_stream_on || output_single_on) output_angles();
     }
@@ -819,12 +1000,16 @@ void loop()
       // Apply sensor calibration
       compensate_sensor_errors();
     
+#if DEBUG__USE_ONLY_DMP_M0 == true
+	  Euler_angles_only_DMP_M0();
+#else
       // Run DCM algorithm
       Compass_Heading(); // Calculate magnetic heading
       Matrix_update();
       Normalize();
       Drift_correction();
       Euler_angles();
+#endif // DEBUG__USE_ONLY_DMP_M0
       
       if (output_stream_on || output_single_on) output_both_angles_and_sensors_text();
     }
@@ -836,14 +1021,21 @@ void loop()
     output_single_on = false;
     
 #if DEBUG__PRINT_LOOP_TIME == true
-    Serial.print("loop time (ms) = ");
-    Serial.println(millis() - timestamp);
+    LOG_PORT.print("loop time (ms) = ");
+    LOG_PORT.println(millis() - timestamp);
 #endif
   }
 #if DEBUG__PRINT_LOOP_TIME == true
   else
   {
-    Serial.println("waiting...");
+    LOG_PORT.println("waiting...");
   }
+#else
+#if DEBUG__ADD_LOOP_DELAY == true
+  else
+  {
+	delay(DEBUG__LOOP_DELAY);
+  }
+#endif // DEBUG__ADD_LOOP_DELAY
 #endif
 }

--- a/src/Razor_AHRS/Sensors.ino
+++ b/src/Razor_AHRS/Sensors.ino
@@ -1,11 +1,228 @@
 /* This file is part of the Razor AHRS Firmware */
 
+#if HW__VERSION_CODE == 14001
+/*
+* Known Bug -
+* DMP when enabled will sample sensor data at 200Hz and output to FIFO at the rate
+* specified in the dmp_set_fifo_rate API. The DMP will then sent an interrupt once
+* a sample has been put into the FIFO. Therefore if the dmp_set_fifo_rate is at 25Hz
+* there will be a 25Hz interrupt from the MPU device.
+*
+* There is a known issue in which if you do not enable DMP_FEATURE_TAP
+* then the interrupts will be at 200Hz even if fifo rate
+* is set at a different rate. To avoid this issue include the DMP_FEATURE_TAP
+*
+* DMP sensor fusion works only with gyro at +-2000dps and accel +-2G
+*/
+#define DMP_SAMPLE_RATE    100 // Logging/DMP sample rate(4-200 Hz)
+#define IMU_COMPASS_SAMPLE_RATE 100 // Compass sample rate (4-100 Hz)
+#define IMU_AG_SAMPLE_RATE 100 // Accel/gyro sample rate Must be between 4Hz and 1kHz
+#if DEBUG__USE_DEFAULT_GYRO_FSR_M0 == true
+#define IMU_GYRO_FSR       2000 // Gyro full-scale range (250, 500, 1000, or 2000)
+#else
+#define IMU_GYRO_FSR       2000 // Gyro full-scale range (250, 500, 1000, or 2000)
+#endif // DEBUG__USE_DEFAULT_GYRO_FSR_M0
+#if DEBUG__USE_DEFAULT_ACCEL_FSR_M0 == true
+#define IMU_ACCEL_FSR      2 // Accel full-scale range (2, 4, 8, or 16)
+#else
+#define IMU_ACCEL_FSR      16 // Accel full-scale range (2, 4, 8, or 16)
+#endif // DEBUG__USE_DEFAULT_ACCEL_FSR_M0
+#define IMU_AG_LPF         5 // Accel/Gyro LPF corner frequency (5, 10, 20, 42, 98, or 188 Hz)
+#define ENABLE_GYRO_CALIBRATION true
+
+unsigned short accelFSR = IMU_ACCEL_FSR;
+unsigned short gyroFSR = IMU_GYRO_FSR;
+unsigned short fifoRate = DMP_SAMPLE_RATE;
+
+bool initIMU(void)
+{
+	// imu.begin() should return 0 on success. Will initialize
+	// I2C bus, and reset MPU-9250 to defaults.
+	if (imu.begin() != INV_SUCCESS)
+		return false;
+
+#if DEBUG__ENABLE_INTERRUPT_M0 == true
+	// Use enableInterrupt() to configure the MPU-9250's 
+	// interrupt output as a "data ready" indicator.
+	imu.enableInterrupt();
+
+	// The interrupt level can either be active-high or low.
+	// Configure as active-low, since we'll be using the pin's
+	// internal pull-up resistor.
+	// Options are INT_ACTIVE_LOW or INT_ACTIVE_HIGH
+	imu.setIntLevel(INT_ACTIVE_LOW);
+
+	// The interrupt can be set to latch until data has
+	// been read, or to work as a 50us pulse.
+	// Use latching method -- we'll read from the sensor
+	// as soon as we see the pin go LOW.
+	// Options are INT_LATCHED or INT_50US_PULSE
+	imu.setIntLatched(INT_LATCHED);
+#endif // DEBUG__ENABLE_INTERRUPT_M0
+
+	// Configure sensors:
+	// Set gyro full-scale range: options are 250, 500, 1000, or 2000:
+	imu.setGyroFSR(gyroFSR);
+	// Set accel full-scale range: options are 2, 4, 8, or 16 g 
+	imu.setAccelFSR(accelFSR);
+	// Set gyro/accel LPF: options are5, 10, 20, 42, 98, 188 Hz
+	imu.setLPF(IMU_AG_LPF);
+	// Set gyro/accel sample rate: must be between 4-1000Hz
+	// (note: this value will be overridden by the DMP sample rate)
+	imu.setSampleRate(IMU_AG_SAMPLE_RATE);
+	// Set compass sample rate: between 4-100Hz
+	imu.setCompassSampleRate(IMU_COMPASS_SAMPLE_RATE);
+
+#if DEBUG__USE_DMP_M0 == true
+	// Configure digital motion processor. Use the FIFO to get
+	// data from the DMP.
+	unsigned short dmpFeatureMask = 0;
+	//dmp_set_interrupt_mode(DMP_INT_CONTINUOUS);
+	if (ENABLE_GYRO_CALIBRATION)
+	{
+		// Gyro calibration re-calibrates the gyro after a set amount
+		// of no motion detected
+		dmpFeatureMask |= DMP_FEATURE_GYRO_CAL; //added this line
+		dmpFeatureMask |= DMP_FEATURE_SEND_CAL_GYRO;
+	}
+	else
+	{
+		// Otherwise add raw gyro readings to the DMP
+		dmpFeatureMask |= DMP_FEATURE_SEND_RAW_GYRO;
+	}
+	// Add accel and quaternion's to the DMP
+	dmpFeatureMask |= DMP_FEATURE_SEND_RAW_ACCEL;
+	dmpFeatureMask |= DMP_FEATURE_6X_LP_QUAT;
+	// Because of known issue without DMP_FEATURE_TAP...
+	dmpFeatureMask |= DMP_FEATURE_TAP;
+
+	// Initialize the DMP, and set the FIFO's update rate:
+	imu.dmpBegin(dmpFeatureMask, fifoRate);
+#else
+#if DEBUG__ENABLE_FIFO_M0 == true
+	// Use configureFifo to set which sensors should be stored
+	// in the buffer.  
+	// Parameter to this function can be: INV_XYZ_GYRO, 
+	// INV_XYZ_ACCEL, INV_X_GYRO, INV_Y_GYRO, or INV_Z_GYRO
+	imu.configureFifo(INV_XYZ_GYRO|INV_XYZ_ACCEL);
+
+	// Compass needs to be enabled again here due to a side effect of mpu_configure_fifo()...
+	imu.setSensors(INV_XYZ_GYRO|INV_XYZ_ACCEL|INV_XYZ_COMPASS);
+#endif // DEBUG__ENABLE_FIFO_M0
+#endif // DEBUG__USE_DMP_M0
+
+	return true; // Return success
+}
+
+void loop_imu()
+{
+	// Check IMU for new data, and log it.
+#if DEBUG__USE_DMP_M0 == true
+	if (!imu.fifoAvailable())
+#else
+#if DEBUG__ENABLE_FIFO_M0 == true
+	if (!imu.fifoAvailable())
+#else
+	if (!imu.dataReady())
+#endif // DEBUG__ENABLE_FIFO_M0
+#endif // DEBUG__USE_DMP_M0
+	{
+		num_accel_errors++;
+		if (output_errors) LOG_PORT.println("!ERR: reading accelerometer");
+		num_gyro_errors++;
+		if (output_errors) LOG_PORT.println("!ERR: reading gyroscope");
+		return;
+	}
+
+	// Get the latest data...
+#if DEBUG__USE_DMP_M0 == true
+	while (imu.fifoAvailable())
+	{
+		// Read from the digital motion processor's FIFO.
+		if (imu.dmpUpdateFifo() != INV_SUCCESS)
+#else
+#if DEBUG__ENABLE_FIFO_M0 == true
+	while (imu.fifoAvailable())
+	{
+		if (imu.updateFifo() != INV_SUCCESS)
+#else
+	{
+		if (imu.update(UPDATE_ACCEL|UPDATE_GYRO) != INV_SUCCESS)
+#endif // DEBUG__ENABLE_FIFO_M0
+#endif // DEBUG__USE_DMP_M0
+		{
+			num_accel_errors++;
+			if (output_errors) LOG_PORT.println("!ERR: reading accelerometer");
+			num_gyro_errors++;
+			if (output_errors) LOG_PORT.println("!ERR: reading gyroscope");
+			return;
+		}
+	}
+
+	// Read from the compass.
+	if (imu.updateCompass() != INV_SUCCESS)
+	{
+		num_magn_errors++;
+		if (output_errors) LOG_PORT.println("!ERR: reading magnetometer");
+		return;
+	}
+
+	// Conversion from g to similar unit as older versions of Razor...
+	accel[0] = -250.0f*imu.calcAccel(imu.ax);
+	accel[1] = 250.0f*imu.calcAccel(imu.ay);
+	accel[2] = 250.0f*imu.calcAccel(imu.az);
+	// Conversion from degrees/s to rad/s.
+	gyro[0] = imu.calcGyro(imu.gx)*PI/180.0f;
+	gyro[1] = -imu.calcGyro(imu.gy)*PI/180.0f;
+	gyro[2] = -imu.calcGyro(imu.gz)*PI/180.0f;
+	// Conversion from uT to mGauss.
+	magnetom[0] = (10.0f*imu.calcMag(imu.my));
+	magnetom[1] = (-10.0f*imu.calcMag(imu.mx));
+	magnetom[2] = (10.0f*imu.calcMag(imu.mz));
+}
+
+#if DEBUG__USE_ONLY_DMP_M0 == true
+void Euler_angles_only_DMP_M0(void)
+{
+	Gyro_Vector[0] = GYRO_SCALED_RAD(gyro[0]); //gyro x roll
+	Gyro_Vector[1] = GYRO_SCALED_RAD(gyro[1]); //gyro y pitch
+	Gyro_Vector[2] = GYRO_SCALED_RAD(gyro[2]); //gyro z yaw
+
+	Accel_Vector[0] = accel[0];
+	Accel_Vector[1] = accel[1];
+	Accel_Vector[2] = accel[2];
+
+	imu.computeEulerAngles();
+
+	// Convert from NWU to NED...
+	pitch = -imu.pitch*PI/180.0f;
+	roll = imu.roll*PI/180.0f;
+
+	Compass_Heading(); // Calculate magnetic heading
+
+	float magyaw = -MAG_Heading;
+	float imuyaw = imu.yaw*PI/180.0f;
+	float fusionyaw = 0;
+	float magfusioncoef = 0.0f;
+	if (initialmagyaw == -10000) initialmagyaw = magyaw;
+	if (initialimuyaw == -10000) initialimuyaw = imuyaw;
+	if (!DEBUG__NO_DRIFT_CORRECTION)
+		fusionyaw = magyaw*180.0f/PI;
+	else
+		fusionyaw = atan2((1-magfusioncoef)*sin(imuyaw+initialmagyaw-initialimuyaw)+magfusioncoef*sin(magyaw),
+		(1-magfusioncoef)*cos(imuyaw+initialmagyaw-initialimuyaw)+magfusioncoef*cos(magyaw))*180.0f/PI;
+
+	// Convert from NWU to NED...
+	yaw = -fusionyaw*PI/180.0f;
+}
+#endif // DEBUG__USE_ONLY_DMP_M0
+#else
 // I2C code to read the sensors
 
 // Sensor I2C addresses
-#define ACCEL_ADDRESS ((int) 0x53) // 0x53 = 0xA6 / 2
-#define MAGN_ADDRESS  ((int) 0x1E) // 0x1E = 0x3C / 2
-#define GYRO_ADDRESS  ((int) 0x68) // 0x68 = 0xD0 / 2
+#define ACCEL_ADDRESS ((int16_t) 0x53) // 0x53 = 0xA6 / 2
+#define MAGN_ADDRESS  ((int16_t) 0x1E) // 0x1E = 0x3C / 2
+#define GYRO_ADDRESS  ((int16_t) 0x68) // 0x68 = 0xD0 / 2
 
 // Arduino backward compatibility macros
 #if ARDUINO >= 100
@@ -47,7 +264,7 @@ void Accel_Init()
 void Read_Accel()
 {
   int i = 0;
-  byte buff[6];
+  uint8_t buff[6];
   
   Wire.beginTransmission(ACCEL_ADDRESS); 
   WIRE_SEND(0x32);  // Send address to read from
@@ -66,14 +283,14 @@ void Read_Accel()
   {
     // No multiply by -1 for coordinate system transformation here, because of double negation:
     // We want the gravity vector, which is negated acceleration vector.
-    accel[0] = (((int) buff[3]) << 8) | buff[2];  // X axis (internal sensor y axis)
-    accel[1] = (((int) buff[1]) << 8) | buff[0];  // Y axis (internal sensor x axis)
-    accel[2] = (((int) buff[5]) << 8) | buff[4];  // Z axis (internal sensor z axis)
+    accel[0] = (int16_t)((((uint16_t) buff[3]) << 8) | buff[2]);  // X axis (internal sensor y axis)
+    accel[1] = (int16_t)((((uint16_t) buff[1]) << 8) | buff[0]);  // Y axis (internal sensor x axis)
+    accel[2] = (int16_t)((((uint16_t) buff[5]) << 8) | buff[4]);  // Z axis (internal sensor z axis)
   }
   else
   {
     num_accel_errors++;
-    if (output_errors) Serial.println("!ERR: reading accelerometer");
+    if (output_errors) LOG_PORT.println("!ERR: reading accelerometer");
   }
 }
 
@@ -95,7 +312,7 @@ void Magn_Init()
 void Read_Magn()
 {
   int i = 0;
-  byte buff[6];
+  uint8_t buff[6];
  
   Wire.beginTransmission(MAGN_ADDRESS); 
   WIRE_SEND(0x03);  // Send address to read from
@@ -115,33 +332,33 @@ void Read_Magn()
 // 9DOF Razor IMU SEN-10125 using HMC5843 magnetometer
 #if HW__VERSION_CODE == 10125
     // MSB byte first, then LSB; X, Y, Z
-    magnetom[0] = -1 * ((((int) buff[2]) << 8) | buff[3]);  // X axis (internal sensor -y axis)
-    magnetom[1] = -1 * ((((int) buff[0]) << 8) | buff[1]);  // Y axis (internal sensor -x axis)
-    magnetom[2] = -1 * ((((int) buff[4]) << 8) | buff[5]);  // Z axis (internal sensor -z axis)
+    magnetom[0] = -1 * (int16_t)(((((uint16_t) buff[2]) << 8) | buff[3]));  // X axis (internal sensor -y axis)
+    magnetom[1] = -1 * (int16_t)(((((uint16_t) buff[0]) << 8) | buff[1]));  // Y axis (internal sensor -x axis)
+    magnetom[2] = -1 * (int16_t)(((((uint16_t) buff[4]) << 8) | buff[5]));  // Z axis (internal sensor -z axis)
 // 9DOF Razor IMU SEN-10736 using HMC5883L magnetometer
 #elif HW__VERSION_CODE == 10736
     // MSB byte first, then LSB; Y and Z reversed: X, Z, Y
-    magnetom[0] = -1 * ((((int) buff[4]) << 8) | buff[5]);  // X axis (internal sensor -y axis)
-    magnetom[1] = -1 * ((((int) buff[0]) << 8) | buff[1]);  // Y axis (internal sensor -x axis)
-    magnetom[2] = -1 * ((((int) buff[2]) << 8) | buff[3]);  // Z axis (internal sensor -z axis)
+    magnetom[0] = -1 * (int16_t)(((((uint16_t) buff[4]) << 8) | buff[5]));  // X axis (internal sensor -y axis)
+    magnetom[1] = -1 * (int16_t)(((((uint16_t) buff[0]) << 8) | buff[1]));  // Y axis (internal sensor -x axis)
+    magnetom[2] = -1 * (int16_t)(((((uint16_t) buff[2]) << 8) | buff[3]));  // Z axis (internal sensor -z axis)
 // 9DOF Sensor Stick SEN-10183 and SEN-10321 using HMC5843 magnetometer
 #elif (HW__VERSION_CODE == 10183) || (HW__VERSION_CODE == 10321)
     // MSB byte first, then LSB; X, Y, Z
-    magnetom[0] = (((int) buff[0]) << 8) | buff[1];         // X axis (internal sensor x axis)
-    magnetom[1] = -1 * ((((int) buff[2]) << 8) | buff[3]);  // Y axis (internal sensor -y axis)
-    magnetom[2] = -1 * ((((int) buff[4]) << 8) | buff[5]);  // Z axis (internal sensor -z axis)
+    magnetom[0] = (((uint16_t) buff[0]) << 8) | buff[1];         // X axis (internal sensor x axis)
+    magnetom[1] = -1 * (int16_t)(((((uint16_t) buff[2]) << 8) | buff[3]));  // Y axis (internal sensor -y axis)
+    magnetom[2] = -1 * (int16_t)(((((uint16_t) buff[4]) << 8) | buff[5]));  // Z axis (internal sensor -z axis)
 // 9DOF Sensor Stick SEN-10724 using HMC5883L magnetometer
 #elif HW__VERSION_CODE == 10724
     // MSB byte first, then LSB; Y and Z reversed: X, Z, Y
-    magnetom[0] = (((int) buff[0]) << 8) | buff[1];         // X axis (internal sensor x axis)
-    magnetom[1] = -1 * ((((int) buff[4]) << 8) | buff[5]);  // Y axis (internal sensor -y axis)
-    magnetom[2] = -1 * ((((int) buff[2]) << 8) | buff[3]);  // Z axis (internal sensor -z axis)
+    magnetom[0] = (int16_t)((((uint16_t) buff[0]) << 8) | buff[1]);         // X axis (internal sensor x axis)
+    magnetom[1] = -1 * (int16_t)(((((uint16_t) buff[4]) << 8) | buff[5]));  // Y axis (internal sensor -y axis)
+    magnetom[2] = -1 * (int16_t)(((((uint16_t) buff[2]) << 8) | buff[3]));  // Z axis (internal sensor -z axis)
 #endif
   }
   else
   {
     num_magn_errors++;
-    if (output_errors) Serial.println("!ERR: reading magnetometer");
+    if (output_errors) LOG_PORT.println("!ERR: reading magnetometer");
   }
 }
 
@@ -181,7 +398,7 @@ void Gyro_Init()
 void Read_Gyro()
 {
   int i = 0;
-  byte buff[6];
+  uint8_t buff[6];
   
   Wire.beginTransmission(GYRO_ADDRESS); 
   WIRE_SEND(0x1D);  // Sends address to read from
@@ -198,13 +415,14 @@ void Read_Gyro()
   
   if (i == 6)  // All bytes received?
   {
-    gyro[0] = -1 * ((((int) buff[2]) << 8) | buff[3]);    // X axis (internal sensor -y axis)
-    gyro[1] = -1 * ((((int) buff[0]) << 8) | buff[1]);    // Y axis (internal sensor -x axis)
-    gyro[2] = -1 * ((((int) buff[4]) << 8) | buff[5]);    // Z axis (internal sensor -z axis)
+    gyro[0] = -1 * (int16_t)(((((uint16_t) buff[2]) << 8) | buff[3]));    // X axis (internal sensor -y axis)
+    gyro[1] = -1 * (int16_t)(((((uint16_t) buff[0]) << 8) | buff[1]));    // Y axis (internal sensor -x axis)
+    gyro[2] = -1 * (int16_t)(((((uint16_t) buff[4]) << 8) | buff[5]));    // Z axis (internal sensor -z axis)
   }
   else
   {
     num_gyro_errors++;
-    if (output_errors) Serial.println("!ERR: reading gyroscope");
+    if (output_errors) LOG_PORT.println("!ERR: reading gyroscope");
   }
 }
+#endif // HW__VERSION_CODE


### PR DESCRIPTION
Resolves #28. The firmware modifications to support the M0 were originally made from the latest version of https://github.com/Razor-AHRS/razor-9dof-ahrs, forked in https://github.com/lebarsfa/razor-9dof-ahrs. Then, the ROS-specific modifications from https://github.com/KristofRobot/razor_imu_9dof were added to add ROS compatibility. Finally, following a suggestion on https://answers.ros.org/question/261398/sparkfun-9dof-razor-imu-sen-14001/, this pull request is proposed, and a pull request to https://github.com/Razor-AHRS/razor-9dof-ahrs will be proposed soon...